### PR TITLE
Migrate data store resources

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,9 +79,6 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Install dependencies
-          command: apk add --update make
-      - run:
           name: Format and validate
           command: |
             cd templates/terraform

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,7 @@ jobs:
           command: apk add --update make
       - run:
           name: Format and validate
-          command: >
+          command: |
             cd templates/terraform
             terraform init -backend=false
             terraform fmt -recursive -check -diff

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,6 +73,21 @@ jobs:
           name: Validate templates
           command: cfn-lint templates/cloudformation/*
 
+  terraform-lint:
+    docker:
+      - image: docker.mirror.hashicorp.services/hashicorp/terraform:light
+    steps:
+      - checkout
+      - run:
+          name: Install dependencies
+          command: apk add --update make
+      - run:
+          name: Format and validate
+          command: >
+            cd templates/terraform
+            terraform init -backend=false
+            terraform fmt -recursive -check -diff
+            terraform validate
 
 workflows:
   version: 2
@@ -81,6 +96,7 @@ workflows:
     jobs:
       - run-trufflehog-scan
       - cloudformation-lint
+      - terraform-lint
       - aws-s3/sync:
           name: publish-resources-dev
           auth:
@@ -92,6 +108,7 @@ workflows:
           requires:
             - run-trufflehog-scan
             - cloudformation-lint
+            - terraform-lint
           filters:
             branches:
               only:
@@ -109,6 +126,7 @@ workflows:
           requires:
             - run-trufflehog-scan
             - cloudformation-lint
+            - terraform-lint
           filters:
             branches:
               only:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Publicly available templates and other resources to assist customers with onboar
 
 ### CloudFormation
 
-#### Monte Carlo's agent template for customer-hosted deployments in AWS ([Source](templates/cloudformation/aws_apollo_agent.yaml))
+#### <ins>Monte Carlo's agent template for customer-hosted agent & object storage deployments in AWS ([source](templates/cloudformation/aws_apollo_agent.yaml))</ins>
 
 This template deploys Monte Carlo's [containerized agent](https://hub.docker.com/r/montecarlodata/agent) (Beta) on AWS
 Lambda, along with storage, and roles:
@@ -15,12 +15,22 @@ Lambda, along with storage, and roles:
 
 See [here](https://docs.getmontecarlo.com/docs/platform-architecture) for platform details
 and [here](https://docs.getmontecarlo.com/docs/create-and-register-an-aws-agent) for how to create and register an agent
-on AWS.
+on AWS. A Terraform variant can be
+found [here](https://registry.terraform.io/modules/monte-carlo-data/mcd-agent/aws/latest).
 
 For any developers of the agent [this](examples/agent/test_execution.sh) simple script can be handy in testing basic
 execution of the agent.
 
-#### Basic VPC ([Source](templates/cloudformation/basic_vpc.yaml))
+#### <ins>S3 Data Store for customer-hosted object storage deployments in AWS ([source](templates/cloudformation/aws_data_store.yaml))</ins>
+
+This sample template creates a S3 bucket and assumable IAM role for the cloud with customer-hosted object storage
+deployment model.
+
+See [here](https://docs.getmontecarlo.com/docs/platform-architecture) for platform details
+and [here](https://docs.getmontecarlo.com/docs/direct-connection-with-an-aws-data-store) for how to create and register
+a data store on AWS.
+
+#### <ins>Basic VPC ([source](templates/cloudformation/basic_vpc.yaml))</ins>
 
 This template creates a VPC with 2 public and private subnets. Includes a NAT, IGW, and S3 VPCE.
 Can be used to connect an Agent to a VPC for peering and/or IP whitelisting.
@@ -91,38 +101,68 @@ Resources:
 
 ### Terraform
 
-Coming soon!
+#### <ins>GCS Data Store for customer-hosted object storage deployments in GCP ([source](templates/terraform/gcs_data_store.tf))</ins>
+
+This sample config file creates a GCS bucket, role, service account, and key for the cloud with customer-hosted
+object storage deployment model on GCP.
+
+Note that this will persist a key in the remote state used by Terraform. Please take appropriate measures to protect
+your remote state.
+
+See [here](https://docs.getmontecarlo.com/docs/platform-architecture) for platform details
+and [here](https://docs.getmontecarlo.com/docs/direct-connection-with-a-gcp-data-store) for how to create and register
+a data store on GCP.
 
 ## Development
 
-### CloudFormation
+### Local
 
-1. Install the [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)
+1. Install
+   the [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html), [Terraform](https://developer.hashicorp.com/terraform/install)
+   and any providers.
 2. Install any dependencies and pre-commit hooks
     ```
     pyenv activate mcd-iac-resources
     pip install -r requirements-dev.txt; pre-commit install
     ```
-   This hook will lint all templates in the `templates/` directory
-   using [cfn-lint](https://github.com/aws-cloudformation/cfn-lint). CircleCI will also validate templates.
 
-Then any IaC templates can be created using commands
+   This hook will lint all CloudFormation templates in the `templates/` directory
+   using [cfn-lint](https://github.com/aws-cloudformation/cfn-lint).
+
+Any CloudFormation templates can be created using commands
 like [deploy](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/cloudformation/deploy/index.html) or
-the console.
+the console. Similarly, any Terraform config files can be deployed
+using [terraform apply](https://developer.hashicorp.com/terraform/cli/commands/apply) (and plan).
 
-After merging to `dev` CircleCI will publish any templates or resources in the `templates/` directory
-to `s3://mcd-dev-public-resources`.
+During development, you might want to configure Terraform Cloud as the backend. To do so you can add the following
+snippet:
 
-Note that any templates in this bucket are considered experimental and not intended for production use.
+```
+terraform {
+  cloud {
+    organization = "<org>"
 
-### Terraform
+    workspaces {
+      name = "<workspace>"
+    }
+  }
+}
+```
 
-Coming soon!
+This also requires you to execute `terraform login` before initializing. You will also have to set the execution mode
+to "Local".
+
+### Dev
+
+After merging to `dev` CircleCI will lint, validate, and publish any templates or resources in the `templates/`
+directory to `s3://mcd-dev-public-resources`.
+
+Note that any files in this bucket are considered experimental and are not intended for production use.
 
 ## Releases
 
 After merging to `main` CircleCI will publish any templates or resources in the `templates/` directory
-to `s3://mcd-public-resources` (requires review, validation, and approval).
+to `s3://mcd-public-resources` (requires review, linting, validation, and approval).
 
 ## Additional Resources
 
@@ -130,6 +170,7 @@ to `s3://mcd-public-resources` (requires review, validation, and approval).
 |-------------------------------------------------------------------|----------------------------------------------------------------|
 | Monte Carlo's containerized agent                                 | https://github.com/monte-carlo-data/apollo-agent               |
 | Monte Carlo's agent module for customer-hosted deployments in GCP | https://github.com/monte-carlo-data/terraform-google-mcd-agent |
+| Monte Carlo's agent module for customer-hosted deployments in AWS | https://github.com/monte-carlo-data/terraform-aws-mcd-agent    |
 
 ## License
 

--- a/templates/cloudformation/aws_data_store.yaml
+++ b/templates/cloudformation/aws_data_store.yaml
@@ -1,0 +1,105 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: >
+  Sample template to create a S3 bucket and assumable IAM role for the cloud with customer-hosted object storage 
+  deployment model. Additional details and options can be found here: https://docs.getmontecarlo.com/docs/deployment-and-connecting
+Metadata:
+  License: >
+    Copyright 2023 Monte Carlo Data, Inc.
+
+    The Software contained herein (the “Software”) is the intellectual property of Monte Carlo Data, Inc. (“Licensor”),
+    and Licensor retains all intellectual property rights in the Software, including any and all derivatives, changes and
+    improvements thereto. Only customers who have entered into a commercial agreement with Licensor for use or
+    purchase of the Software (“Licensee”) are licensed or otherwise authorized to use the Software, and any Licensee
+    agrees that it obtains no copyright or other intellectual property rights to the Software, except for the license
+    expressly granted below or in accordance with the terms of their commercial agreement with Licensor (the
+    “Agreement”). Subject to the terms and conditions of the Agreement, Licensor grants Licensee a non-exclusive,
+    non-transferable, non-sublicensable, revocable, limited right and license to use the Software, in each case solely
+    internally within Licensee’s organization for non-commercial purposes and only in connection with the service
+    provided by Licensor pursuant to the Agreement, and in object code form only. Without Licensor’s express prior
+    written consent, Licensee may not, directly or indirectly, (i) distribute the Software, any portion thereof, or any
+    modifications, enhancements, or derivative works of any of the foregoing (collectively, the “Derivatives”) to any
+    third party, (ii) license, market, sell, offer for sale or otherwise attempt to commercialize any Software, Derivatives,
+    or portions thereof, (iii) use the Software, Derivatives, or any portion thereof for the benefit of any third party, (iv)
+    use the Software, Derivatives, or any portion thereof in any manner or with respect to any commercial activity
+    which competes, or is reasonably likely to compete, with any business that Licensor conducts, proposes to conduct
+    or demonstrably anticipates conducting, at any time; or (v) seek any patent or other intellectual property rights or
+    protections over or in connection with any Software of Derivatives.
+  AWS::CloudFormation::Interface:
+    ParameterLabels:
+      MonteCarloCloudAccountId:
+        default: Monte Carlo AWS Account ID
+Parameters:
+  MonteCarloCloudAccountId:
+    Description: >
+      Please select the Monte Carlo account your agent is hosted in. This can be found in the 
+      'settings/integrations/collectors' tab on the UI or via the 'montecarlo collectors list' command on the CLI.
+    Type: String
+    Default: 190812797848
+    AllowedValues: [ 190812797848, 799135046351 ]
+Resources:
+  ObjectStoreBucket:
+    Properties:
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+      LifecycleConfiguration:
+        Rules:
+          - ExpirationInDays: 90
+            Prefix: 'custom-sql-output-samples/'
+            Status: Enabled
+          - ExpirationInDays: 90
+            Prefix: 'rca'
+            Status: Enabled
+          - ExpirationInDays: 90
+            Prefix: 'idempotent/'
+            Status: Enabled
+    Type: AWS::S3::Bucket
+  ObjectStoreRole:
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !Sub 'arn:aws:iam::${MonteCarloCloudAccountId}:root'
+            Action: sts:AssumeRole
+            Condition:
+              StringEquals:
+                sts:ExternalId: !Select [ 2, !Split [ '/', !Ref AWS::StackId ] ]
+      Policies:
+        - PolicyName: 's3-policy'
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Action:
+                  - 's3:PutObject'
+                  - 's3:GetObject'
+                  - 's3:DeleteObject'
+                  - 's3:ListBucket'
+                  - 's3:GetBucketPublicAccessBlock'
+                  - 's3:GetBucketPolicyStatus'
+                  - 's3:GetBucketAcl'
+                Resource:
+                  - !GetAtt ObjectStoreBucket.Arn
+                  - !Sub '${ObjectStoreBucket.Arn}/*'
+                Effect: Allow
+      Tags:
+        - Key: MonteCarloData
+          Value: ''
+    Type: AWS::IAM::Role
+Outputs:
+  ObjectStoreBucketName:
+    Description: Name of the S3 bucket. To be used in registering.
+    Value: !Ref ObjectStoreBucket
+  ObjectStoreRoleArn:
+    Description: ARN for the assumable role. To be used in registering.
+    Value: !GetAtt ObjectStoreRole.Arn
+  ObjectStoreRoleExternalId:
+    Description: External ID for the assumable role. To be used in registering.
+    Value: !Select [ 2, !Split [ '/', !Ref AWS::StackId ] ]

--- a/templates/terraform/gcs_data_store.tf
+++ b/templates/terraform/gcs_data_store.tf
@@ -1,0 +1,142 @@
+/*
+Copyright 2023 Monte Carlo Data, Inc.
+
+The Software contained herein (the “Software”) is the intellectual property of Monte Carlo Data, Inc. (“Licensor”),
+and Licensor retains all intellectual property rights in the Software, including any and all derivatives, changes and
+improvements thereto. Only customers who have entered into a commercial agreement with Licensor for use or
+purchase of the Software (“Licensee”) are licensed or otherwise authorized to use the Software, and any Licensee
+agrees that it obtains no copyright or other intellectual property rights to the Software, except for the license
+expressly granted below or in accordance with the terms of their commercial agreement with Licensor (the
+“Agreement”). Subject to the terms and conditions of the Agreement, Licensor grants Licensee a non-exclusive,
+non-transferable, non-sublicensable, revocable, limited right and license to use the Software, in each case solely
+internally within Licensee’s organization for non-commercial purposes and only in connection with the service
+provided by Licensor pursuant to the Agreement, and in object code form only. Without Licensor’s express prior
+written consent, Licensee may not, directly or indirectly, (i) distribute the Software, any portion thereof, or any
+modifications, enhancements, or derivative works of any of the foregoing (collectively, the “Derivatives”) to any
+third party, (ii) license, market, sell, offer for sale or otherwise attempt to commercialize any Software, Derivatives,
+or portions thereof, (iii) use the Software, Derivatives, or any portion thereof for the benefit of any third party, (iv)
+use the Software, Derivatives, or any portion thereof in any manner or with respect to any commercial activity
+which competes, or is reasonably likely to compete, with any business that Licensor conducts, proposes to conduct
+or demonstrably anticipates conducting, at any time; or (v) seek any patent or other intellectual property rights or
+protections over or in connection with any Software of Derivatives.
+*/
+
+/*
+Sample Terraform config file to create a GCS bucket, role, service account,and key for the cloud with customer-hosted
+object storage deployment model on GCP. Additional details and options can be found here: https://docs.getmontecarlo.com/docs/deployment-and-connecting
+
+Note that this will persist a key in the remote state used by Terraform. Please take appropriate measures to protect your remote state.
+
+Usage example (requires Terraform and the gCloud CLI):
+  terraform init
+  terraform apply
+
+Inputs:
+  project_id - The GCP project ID to deploy into [REQUIRED].
+  location - The GCP location (region) to deploy into.
+
+Outputs:
+  bucket_name - The generated GCS bucket.
+  key - The Key file for Monte Carlo to access the bucket.
+            Can retrieve via `terraform output -json 'key' | jq -r '.' | base64 -d > key.json`
+
+  These can be used when registering: https://clidocs.getmontecarlo.com/#montecarlo-agents-register-gcs-store
+*/
+
+
+terraform {
+  required_version = ">= 1.3"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.1.0"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project_id
+}
+
+variable "project_id" {
+  description = "The GCP project ID to deploy into."
+  type        = string
+}
+
+variable "location" {
+  description = "The GCP location (region) to deploy into."
+  type        = string
+  default     = "us-east4" # Northern Virginia
+}
+
+output "bucket_name" {
+  value       = google_storage_bucket.this.name
+  description = "The generated GCS bucket."
+}
+
+output "key" {
+  value       = google_service_account_key.this.private_key
+  description = "The Key file for Monte Carlo to access the bucket."
+  sensitive   = true
+}
+
+resource "random_id" "mcd_id" {
+  byte_length = 4
+}
+
+resource "google_storage_bucket" "this" {
+  name     = "mcd-store-${random_id.mcd_id.hex}"
+  location = var.location
+  project  = var.project_id
+  lifecycle_rule {
+    condition {
+      age = 90
+      matches_prefix = [
+        "custom-sql-output-samples/",
+        "rca",
+        "idempotent",
+      ]
+    }
+    action {
+      type = "Delete"
+    }
+  }
+  uniform_bucket_level_access = true
+  public_access_prevention    = "enforced"
+}
+
+resource "google_project_iam_custom_role" "this" {
+  role_id = "mcdStoreRole${random_id.mcd_id.hex}"
+  title   = "MCD Store Role"
+  permissions = [
+    "storage.objects.create",
+    "storage.objects.delete",
+    "storage.objects.get",
+    "storage.objects.list",
+    "storage.objects.update",
+    "storage.buckets.get",
+    "storage.buckets.getIamPolicy"
+  ]
+  project = var.project_id
+}
+
+resource "google_service_account" "this" {
+  account_id   = "mcd-invoker-sa-${random_id.mcd_id.hex}"
+  display_name = "MCD Invoker SA"
+  project      = var.project_id
+}
+
+resource "google_storage_bucket_iam_binding" "mcd_agent_service_sa_binding" {
+  bucket = google_storage_bucket.this.name
+  role   = "projects/${var.project_id}/roles/${google_project_iam_custom_role.this.role_id}"
+
+  members = [
+    "serviceAccount:${google_service_account.this.email}",
+  ]
+}
+
+resource "google_service_account_key" "this" {
+  service_account_id = google_service_account.this.name
+  public_key_type    = "TYPE_X509_PEM_FILE"
+}


### PR DESCRIPTION
This PR ports over the data store samples from with minor changes (like including the license, and resource cleanup + formatting) for simpler management, reviewability, etc.

Additionally, validation and linting for terraform was included in the CI.