### PR TITLE
allow CORS requests to private bucket through presigned URLs

### DIFF
--- a/templates/cloudformation/aws_apollo_agent.yaml
+++ b/templates/cloudformation/aws_apollo_agent.yaml
@@ -144,6 +144,16 @@ Resources:
           - ExpirationInDays: 2
             Prefix: 'mcd/responses/'
             Status: Enabled
+      # CORS configuration required for access through pre-signed URLs from the browser
+      CorsConfiguration:
+        CorsRules:
+          - AllowedHeaders:
+              - '*'
+            AllowedMethods:
+              - GET
+            AllowedOrigins:
+              - 'https://*.getmontecarlo.com'
+            MaxAge: 3000
     Type: AWS::S3::Bucket
   StorageSSLPolicy:
     Properties:

--- a/templates/cloudformation/aws_data_store.yaml
+++ b/templates/cloudformation/aws_data_store.yaml
@@ -59,6 +59,16 @@ Resources:
           - ExpirationInDays: 90
             Prefix: 'idempotent/'
             Status: Enabled
+      # CORS configuration required for access through pre-signed URLs from the browser
+      CorsConfiguration:
+        CorsRules:
+          - AllowedHeaders:
+              - '*'
+            AllowedMethods:
+              - GET
+            AllowedOrigins:
+              - 'https://*.getmontecarlo.com'
+            MaxAge: 3000
     Type: AWS::S3::Bucket
   ObjectStoreRole:
     Properties:


### PR DESCRIPTION
When generating a pre-signed URL to allow the browser to fetch agent-collected data without passing through Monte Carlo infrastructure, we need to allow for CORS requests from our getmontecarlo.com domains.

We use the `*` to allow our preview & test domains to also access the files, and have flexibility on domain setup in the future (e.g. per-tenant domains).