### PR TITLE
KIL-2960 Add sts:AssumeRole policy to Agent execution Role

### DIFF
--- a/templates/cloudformation/aws_apollo_agent.yaml
+++ b/templates/cloudformation/aws_apollo_agent.yaml
@@ -298,6 +298,18 @@ Resources:
                 Resource:
                   - !Sub 'arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${AWS::StackName}-*'
           PolicyName: LambdaInfoPolicy
+        - PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Action:
+                  - sts:AssumeRole
+                Condition:
+                  StringEquals:
+                    iam:ResourceTag/MonteCarloData: ''
+                Effect: Allow
+                Resource:
+                  - '*'
+          PolicyName: AssumeRolePolicy
         - !If
           - ShouldCreateUpdatePolicy
           - PolicyDocument:


### PR DESCRIPTION
#### What's new?
Adds a permission to the Agent lambda that allows it to assume a role with the `MonteCarloData` tag.