### PR TITLE
Increase default concurrency for the AWS agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,11 +166,12 @@ to `s3://mcd-public-resources` (requires review, linting, validation, and approv
 
 ## Additional Resources
 
-| **Description**                                                   | **Link**                                                       |
-|-------------------------------------------------------------------|----------------------------------------------------------------|
-| Monte Carlo's containerized agent                                 | https://github.com/monte-carlo-data/apollo-agent               |
-| Monte Carlo's agent module for customer-hosted deployments in GCP | https://github.com/monte-carlo-data/terraform-google-mcd-agent |
-| Monte Carlo's agent module for customer-hosted deployments in AWS | https://github.com/monte-carlo-data/terraform-aws-mcd-agent    |
+| **Description**                                                     | **Link**                                                        |
+|---------------------------------------------------------------------|-----------------------------------------------------------------|
+| Monte Carlo's containerized agent                                   | https://github.com/monte-carlo-data/apollo-agent                |
+| Monte Carlo's agent module for customer-hosted deployments in GCP   | https://github.com/monte-carlo-data/terraform-google-mcd-agent  |
+| Monte Carlo's agent module for customer-hosted deployments in AWS   | https://github.com/monte-carlo-data/terraform-aws-mcd-agent     |
+| Monte Carlo's agent module for customer-hosted deployments in Azure | https://github.com/monte-carlo-data/terraform-azurerm-mcd-agent |
 
 ## License
 

--- a/templates/cloudformation/aws_apollo_agent.yaml
+++ b/templates/cloudformation/aws_apollo_agent.yaml
@@ -62,7 +62,7 @@ Parameters:
     Default: 190812797848
     AllowedValues: [ 190812797848, 799135046351, 682816785079 ]
   ConcurrentExecutions:
-    Default: 20
+    Default: 42
     Description: The number of concurrent lambda executions for the agent.
     MaxValue: 200
     MinValue: 0

--- a/templates/cloudformation/aws_apollo_agent.yaml
+++ b/templates/cloudformation/aws_apollo_agent.yaml
@@ -204,7 +204,7 @@ Resources:
           MCD_STORAGE_BUCKET_NAME: !Ref Storage
           MCD_AGENT_IS_REMOTE_UPGRADABLE: !If [ ShouldCreateUpdatePolicy, True, False ]
           MCD_AGENT_WRAPPER_TYPE: CLOUDFORMATION
-          MCD_AGENT_WRAPPER_VERSION: 0.1.0
+          MCD_AGENT_WRAPPER_VERSION: 0.1.1
           MCD_STACK_ID: !Ref 'AWS::StackId'
           MCD_LOG_GROUP_ID: !Sub "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/${AWS::Partition}/lambda/${AWS::StackName}-AgentLambda"
           MCD_AGENT_CONNECTED_TO_A_VPC: !If [ ShouldConnectVPC, True, False ]


### PR DESCRIPTION
To better accommodate both sync and job requests (e.g. to prevent the former from fully consuming the quota). Query concurrency still capped by worker.

Related PR: https://github.com/monte-carlo-data/terraform-aws-mcd-agent/pull/6