### PR TITLE
MES-146 Update agent template for CaaS migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ terraform.rc
 
 # IDE files
 .idea/
+/.venv/

--- a/templates/cloudformation/aws_apollo_agent.yaml
+++ b/templates/cloudformation/aws_apollo_agent.yaml
@@ -391,7 +391,7 @@ Resources:
             Principal:
               AWS: !If
                 - ShouldSkipCloudAccountPolicy
-                - [!Sub 'arn:aws:iam::590183797493:root']
+                - ['arn:aws:iam::590183797493:root']
                 - [!Sub 'arn:aws:iam::${CloudAccountId}:root', 'arn:aws:iam::590183797493:root']
             Action: sts:AssumeRole
             Condition:

--- a/templates/cloudformation/aws_apollo_agent.yaml
+++ b/templates/cloudformation/aws_apollo_agent.yaml
@@ -56,10 +56,13 @@ Metadata:
 Parameters:
   CloudAccountId:
     Description: >
-      [Deprecated] For updates leave the previous value, for new deployments use N/A.
+      The service that invokes the agent is being migrated to the AWS Account with ID: 590183797493.
+      For accounts created after April 24th, 2024 select 590183797493, for previously created
+      accounts select the Monte Carlo account your collection service is hosted in.
+      This can be found in the 'settings/integrations/collectors' tab on the UI or via the 'montecarlo collectors list' command on the CLI.
     Type: String
-    Default: 'N/A'
-    AllowedValues: [ 'N/A', '190812797848', '799135046351', '682816785079', '637423407294', '590183797493' ]
+    Default: '590183797493'
+    AllowedValues: [ '190812797848', '799135046351', '682816785079', '637423407294', '590183797493' ]
   ConcurrentExecutions:
     Default: 42
     Description: The number of concurrent lambda executions for the agent.
@@ -123,9 +126,9 @@ Conditions:
     - !Not [ !Equals [ !Join [ '', !Ref ExistingSubnetIds ], 'N/A' ] ]
     - !Not [ !Equals [ !Ref ExistingVpcId, '' ] ]
     - !Not [ !Equals [ !Join [ '', !Ref ExistingSubnetIds ], '' ] ]
-  ShouldSkipCloudAccountPolicy: !Or
-    - !Equals [!Ref 'CloudAccountId', 'N/A']
-    - !Equals [!Ref 'CloudAccountId', '590183797493']
+  ShouldSkipCloudAccountPolicy: !Equals
+    - !Ref 'CloudAccountId'
+    - '590183797493'
 Resources:
   Storage:
     Properties:

--- a/templates/cloudformation/aws_apollo_agent.yaml
+++ b/templates/cloudformation/aws_apollo_agent.yaml
@@ -56,11 +56,10 @@ Metadata:
 Parameters:
   CloudAccountId:
     Description: >
-      Select the Monte Carlo account your collection service is hosted in. This can be found in the 
-      'settings/integrations/collectors' tab on the UI or via the 'montecarlo collectors list' command on the CLI.
+      [Deprecated] For updates leave the previous value, for new deployments use N/A.
     Type: String
-    Default: 590183797493
-    AllowedValues: [ 190812797848, 799135046351, 682816785079, 637423407294, 590183797493 ]
+    Default: 'N/A'
+    AllowedValues: [ 'N/A', '190812797848', '799135046351', '682816785079', '637423407294', '590183797493' ]
   ConcurrentExecutions:
     Default: 42
     Description: The number of concurrent lambda executions for the agent.
@@ -124,6 +123,9 @@ Conditions:
     - !Not [ !Equals [ !Join [ '', !Ref ExistingSubnetIds ], 'N/A' ] ]
     - !Not [ !Equals [ !Ref ExistingVpcId, '' ] ]
     - !Not [ !Equals [ !Join [ '', !Ref ExistingSubnetIds ], '' ] ]
+  ShouldSkipCloudAccountPolicy: !Or
+    - !Equals [!Ref 'CloudAccountId', 'N/A']
+    - !Equals [!Ref 'CloudAccountId', '590183797493']
 Resources:
   Storage:
     Properties:
@@ -204,7 +206,7 @@ Resources:
           MCD_STORAGE_BUCKET_NAME: !Ref Storage
           MCD_AGENT_IS_REMOTE_UPGRADABLE: !If [ ShouldCreateUpdatePolicy, True, False ]
           MCD_AGENT_WRAPPER_TYPE: CLOUDFORMATION
-          MCD_AGENT_WRAPPER_VERSION: 0.1.3
+          MCD_AGENT_WRAPPER_VERSION: 0.1.4
           MCD_STACK_ID: !Ref 'AWS::StackId'
           MCD_LOG_GROUP_ID: !Sub "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/${AWS::Partition}/lambda/${AWS::StackName}-AgentLambda"
           MCD_AGENT_CONNECTED_TO_A_VPC: !If [ ShouldConnectVPC, True, False ]
@@ -387,7 +389,10 @@ Resources:
         Statement:
           - Effect: Allow
             Principal:
-              AWS: !Sub 'arn:aws:iam::${CloudAccountId}:root'
+              AWS: !If
+                - ShouldSkipCloudAccountPolicy
+                - [!Sub 'arn:aws:iam::590183797493:root']
+                - [!Sub 'arn:aws:iam::${CloudAccountId}:root', 'arn:aws:iam::590183797493:root']
             Action: sts:AssumeRole
             Condition:
               StringEquals:

--- a/templates/cloudformation/aws_data_store.yaml
+++ b/templates/cloudformation/aws_data_store.yaml
@@ -31,11 +31,17 @@ Metadata:
 Parameters:
   MonteCarloCloudAccountId:
     Description: >
-      Please select the Monte Carlo account your agent is hosted in. This can be found in the 
-      'settings/integrations/collectors' tab on the UI or via the 'montecarlo collectors list' command on the CLI.
+      The service that uses the bucket is being migrated to the AWS Account with ID: 590183797493.
+      For accounts created after April 24th, 2024 select 590183797493, for previously created
+      accounts select the Monte Carlo account your collection service is hosted in.
+      This can be found in the 'settings/integrations/collectors' tab on the UI or via the 'montecarlo collectors list' command on the CLI.
     Type: String
     Default: 590183797493
     AllowedValues: [ 190812797848, 799135046351, 682816785079, 637423407294, 590183797493 ]
+Conditions:
+  ShouldSkipCloudAccountPolicy: !Equals
+    - !Ref 'MonteCarloCloudAccountId'
+    - '590183797493'
 Resources:
   ObjectStoreBucket:
     Properties:
@@ -78,7 +84,10 @@ Resources:
         Statement:
           - Effect: Allow
             Principal:
-              AWS: !Sub 'arn:aws:iam::${MonteCarloCloudAccountId}:root'
+              AWS: !If
+                - ShouldSkipCloudAccountPolicy
+                - ['arn:aws:iam::590183797493:root']
+                - [!Sub 'arn:aws:iam::${MonteCarloCloudAccountId}:root', 'arn:aws:iam::590183797493:root']
             Action: sts:AssumeRole
             Condition:
               StringEquals:


### PR DESCRIPTION
- This PR updates the policy for the invocation role defined by the agent to accept invocations from the new CaaS account: `590183797493`.
- For the migration process, we'll need the agent to accept invocations from both accounts, first from the account hosting the DC now (before the migration) and then from the CaaS account (once the migration is ready).
